### PR TITLE
Fix: Update 'Improve Docs' link to point to GitHub Issues

### DIFF
--- a/src/components/ArticleFooter/index.tsx
+++ b/src/components/ArticleFooter/index.tsx
@@ -16,7 +16,7 @@ export default function ArticleFooter(): React.ReactNode {
           <div className={styles.actions}>
             <Link
               className="button button--primary button--md"
-              to="https://docs.cedra.network/"
+              to="https://github.com/cedra-labs/docs/issues"
               target="_blank"
             >
               Improve Docs & Report Issues


### PR DESCRIPTION
I noticed the "Improve Docs & Report Issues" link at the bottom of each page was pointing to the homepage. This wasn't the ideal place for you to report issues or suggest improvements.

I've updated the link to point directly to the GitHub Issues page for the docs repository, which is a more appropriate and helpful destination for this call to action.